### PR TITLE
feat: Add CVE conversion triage page

### DIFF
--- a/gcp/website/frontend3/src/templates/triage.html
+++ b/gcp/website/frontend3/src/templates/triage.html
@@ -6,7 +6,7 @@
   <h1>CVE Conversion Triager</h1>
 
   <div class="input-section">
-    <md-textfield-with-enter label="Vulnerability ID" id="vuln-id-input" placeholder="e.g. CVE-2023-1234"></md-textfield-with-enter>
+    <input type="text" id="vuln-id-input" placeholder="e.g. CVE-2023-1234" class="standard-input">
     <button id="load-btn" class="button">Load</button>
   </div>
 

--- a/gcp/website/frontend3/src/templates/triage.html
+++ b/gcp/website/frontend3/src/templates/triage.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% set active_section = 'triage' %}
+
+{% block content %}
+<div class="triage-container">
+  <h1>CVE Conversion Triager</h1>
+
+  <div class="input-section">
+    <md-textfield-with-enter label="Vulnerability ID" id="vuln-id-input" placeholder="e.g. CVE-2023-1234"></md-textfield-with-enter>
+    <button id="load-btn" class="button">Load</button>
+  </div>
+
+  <div class="triage-grid">
+    {% for i in range(1, 4) %}
+    <div class="triage-column" id="column-{{ i }}">
+      <div class="column-header">
+        <label for="source-select-{{ i }}">Source:</label>
+        <div class="select-wrapper">
+          <select id="source-select-{{ i }}" class="source-select">
+            <option value="">Select Source...</option>
+            <optgroup label="Test Instance (gs://osv-test-cve-conversion)">
+              <option value="test-nvd">NVD-OSV (JSON)</option>
+              <option value="test-cve5">CVE5 (JSON)</option>
+              <option value="test-osv">OSV Output (JSON)</option>
+              <option value="test-nvd-metrics">NVD Metrics</option>
+              <option value="test-cve5-metrics">CVE5 Metrics</option>
+            </optgroup>
+            <optgroup label="Prod Instance (gs://cve-conversion)">
+              <option value="prod-nvd">NVD-OSV (JSON)</option>
+              <option value="prod-cve5">CVE5 (JSON)</option>
+              <option value="prod-osv">OSV Output (JSON)</option>
+              <option value="prod-nvd-metrics">NVD Metrics</option>
+              <option value="prod-cve5-metrics">CVE5 Metrics</option>
+            </optgroup>
+            <optgroup label="API">
+              <option value="api-test">api.test.osv.dev</option>
+              <option value="api-prod">api.osv.dev</option>
+            </optgroup>
+          </select>
+        </div>
+      </div>
+      <div class="content-display">
+        <div class="loading-spinner hidden">
+          <md-circular-progress indeterminate></md-circular-progress>
+        </div>
+        <pre class="json-content">Select a source to view content</pre>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/gcp/website/frontend3/src/triage.js
+++ b/gcp/website/frontend3/src/triage.js
@@ -1,0 +1,141 @@
+import "./triage.scss";
+import "@material/web/textfield/filled-text-field.js";
+import "@material/web/button/filled-button.js";
+import "@material/web/progress/circular-progress.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const vulnIdInput = document.getElementById("vuln-id-input");
+  const loadBtn = document.getElementById("load-btn");
+  const columns = document.querySelectorAll(".triage-column");
+
+  // Map selection values to their respective endpoints/paths
+  const sourceConfigMap = {
+    // Test Instance
+    "test-nvd": {
+      bucket: "osv-test-cve-osv-conversion",
+      pathTemplate: "nvd-osv/{id}.json",
+    },
+    "test-cve5": {
+      bucket: "osv-test-cve-osv-conversion",
+      pathTemplate: "cve5/{id}.json",
+    },
+    "test-osv": {
+      bucket: "osv-test-cve-osv-conversion",
+      pathTemplate: "osv-output/{id}.json",
+    },
+    "test-nvd-metrics": {
+      bucket: "osv-test-cve-osv-conversion",
+      pathTemplate: "nvd-osv/{id}.metrics.json",
+    },
+    "test-cve5-metrics": {
+      bucket: "osv-test-cve-osv-conversion",
+      pathTemplate: "cve5/{id}.metrics.json",
+    },
+    // Prod Instance
+    "prod-nvd": {
+      bucket: "cve-osv-conversion",
+      pathTemplate: "nvd-osv/{id}.json",
+    },
+    "prod-cve5": {
+      bucket: "cve-osv-conversion",
+      pathTemplate: "cve5/{id}.json",
+    },
+    "prod-osv": {
+      bucket: "cve-osv-conversion",
+      pathTemplate: "osv-output/{id}.json",
+    },
+    "prod-nvd-metrics": {
+      bucket: "cve-osv-conversion",
+      pathTemplate: "nvd-osv/{id}.metrics.json",
+    },
+    "prod-cve5-metrics": {
+      bucket: "cve-osv-conversion",
+      pathTemplate: "cve5/{id}.metrics.json",
+    },
+    // API
+    "api-test": {
+      urlTemplate: "https://api.test.osv.dev/v1/vulns/{id}",
+    },
+    "api-prod": {
+      urlTemplate: "https://api.osv.dev/v1/vulns/{id}",
+    },
+  };
+
+  async function fetchData(sourceKey, vulnId) {
+    if (!sourceKey || !vulnId) return null;
+
+    const config = sourceConfigMap[sourceKey];
+    let url;
+
+    if (config.bucket) {
+      const path = config.pathTemplate.replace("{id}", vulnId);
+      url = `/triage/proxy?bucket=${config.bucket}&path=${encodeURIComponent(path)}`;
+    } else if (config.urlTemplate) {
+      url = config.urlTemplate.replace("{id}", vulnId);
+    } else {
+        return Promise.reject("Invalid configuration");
+    }
+
+    const response = await fetch(url);
+    if (!response.ok) {
+        if (response.status === 404) {
+             throw new Error("Not Found");
+        }
+        throw new Error(`Error: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  function updateColumn(column) {
+    const select = column.querySelector(".source-select");
+    const contentPre = column.querySelector(".json-content");
+    const spinner = column.querySelector(".loading-spinner");
+    const sourceKey = select.value;
+    const vulnId = vulnIdInput.value.trim();
+
+    if (!sourceKey) {
+        contentPre.textContent = "Select a source to view content";
+        return;
+    }
+
+    if (!vulnId) {
+      contentPre.textContent = "Please enter a Vulnerability ID";
+      return;
+    }
+
+    spinner.classList.remove("hidden");
+    contentPre.textContent = "";
+
+    fetchData(sourceKey, vulnId)
+      .then((data) => {
+        contentPre.textContent = JSON.stringify(data, null, 2);
+      })
+      .catch((error) => {
+        contentPre.textContent = error.message;
+      })
+      .finally(() => {
+        spinner.classList.add("hidden");
+      });
+  }
+
+  loadBtn.addEventListener("click", () => {
+    columns.forEach((col) => updateColumn(col));
+  });
+
+  // Also handle Enter key on the input field
+  vulnIdInput.addEventListener("keyup", (e) => {
+      if (e.key === "Enter") {
+          columns.forEach((col) => updateColumn(col));
+      }
+  });
+
+  // Individual column updates when dropdown changes
+  columns.forEach((col) => {
+    const select = col.querySelector(".source-select");
+    select.addEventListener("change", () => {
+        if (vulnIdInput.value.trim()) {
+            updateColumn(col);
+        }
+    });
+  });
+});

--- a/gcp/website/frontend3/src/triage.scss
+++ b/gcp/website/frontend3/src/triage.scss
@@ -11,8 +11,18 @@
   margin-bottom: 20px;
 }
 
-#vuln-id-input {
+.standard-input {
   width: 300px;
+  padding: 10px;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+#load-btn {
+  padding: 10px 20px;
+  font-size: 16px;
+  cursor: pointer;
 }
 
 .triage-grid {

--- a/gcp/website/frontend3/src/triage.scss
+++ b/gcp/website/frontend3/src/triage.scss
@@ -1,0 +1,71 @@
+.triage-container {
+  padding: 20px;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.input-section {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+#vuln-id-input {
+  width: 300px;
+}
+
+.triage-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+.triage-column {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  height: 80vh;
+}
+
+.column-header {
+  padding: 10px;
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #ccc;
+}
+
+.select-wrapper {
+  margin-top: 5px;
+}
+
+.source-select {
+  width: 100%;
+  padding: 5px;
+}
+
+.content-display {
+  flex-grow: 1;
+  padding: 10px;
+  overflow: auto;
+  position: relative; /* For spinner positioning */
+}
+
+.json-content {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-family: monospace;
+  font-size: 12px;
+  margin: 0;
+}
+
+.loading-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.hidden {
+  display: none;
+}

--- a/gcp/website/frontend3/webpack.dev.js
+++ b/gcp/website/frontend3/webpack.dev.js
@@ -9,6 +9,7 @@ module.exports = {
   entry: {
     main: './src/index.js',
     linter: './src/linter.js',
+    triage: './src/triage.js',
   },
   output: {
     path: path.resolve(__dirname, '../dist'),
@@ -35,7 +36,7 @@ module.exports = {
   plugins: [
     new CopyPlugin({
       patterns: [
-        { from: './src/templates', to: '.', globOptions: { ignore: ['**/base.html'] } },
+        { from: './src/templates', to: '.', globOptions: { ignore: ['**/base.html', '**/triage.html'] } },
         { from: './img/*', to: 'static/img/[name][ext]' },
       ],
     }),
@@ -50,6 +51,12 @@ module.exports = {
       template: './src/templates/linter/index.html',
       chunks: ['linter'],
       excludeChunks: ['main'],
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'triage.html',
+      template: './src/templates/triage.html',
+      chunks: ['triage'],
+      excludeChunks: ['main', 'linter'],
     }),
     new MiniCssExtractPlugin({
       filename: 'static/[name].css'

--- a/gcp/website/frontend3/webpack.prod.js
+++ b/gcp/website/frontend3/webpack.prod.js
@@ -9,6 +9,7 @@ module.exports = {
   entry: {
     main: './src/index.js',
     linter: './src/linter.js',
+    triage: './src/triage.js',
   },
   output: {
     path: path.resolve(__dirname, '../dist'),
@@ -35,7 +36,7 @@ module.exports = {
   plugins: [
     new CopyPlugin({
       patterns: [
-        { from: './src/templates/*.html', to: '[name].html' },
+        { from: './src/templates/*.html', to: '[name].html', globOptions: { ignore: ['**/base.html', '**/triage.html'] } },
         { from: './img/*', to: 'static/img/[name][ext]' },
       ],
     }),
@@ -50,6 +51,12 @@ module.exports = {
       template: './src/templates/linter/index.html',
       chunks: ['linter'],
       excludeChunks: ['main'],
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'triage.html',
+      template: './src/templates/triage.html',
+      chunks: ['triage'],
+      excludeChunks: ['main', 'linter'],
     }),
     new MiniCssExtractPlugin({
       filename: 'static/[name].[contenthash].css'

--- a/gcp/website/main.py
+++ b/gcp/website/main.py
@@ -22,6 +22,7 @@ import cache
 import frontend_handlers
 import handlers
 import linter_api
+import triage_handlers
 import osv.logs
 
 ndb_client = ndb.Client()
@@ -46,6 +47,7 @@ def create_app():
   flask_app.register_blueprint(handlers.blueprint)
   flask_app.register_blueprint(frontend_handlers.blueprint)
   flask_app.register_blueprint(linter_api.blueprint)
+  flask_app.register_blueprint(triage_handlers.blueprint)
   flask_app.config['TEMPLATES_AUTO_RELOAD'] = True
   flask_app.config['COMPRESS_MIMETYPES'] = ['text/html']
 

--- a/gcp/website/triage_handlers.py
+++ b/gcp/website/triage_handlers.py
@@ -6,47 +6,47 @@ from google.cloud import storage
 
 blueprint = Blueprint('triage_handlers', __name__)
 
-ALLOWED_BUCKETS = {
-    'cve-osv-conversion',
-    'osv-test-cve-osv-conversion'
-}
+ALLOWED_BUCKETS = {'cve-osv-conversion', 'osv-test-cve-osv-conversion'}
 
 _STORAGE_CLIENT = None
 
+
 def get_storage_client():
-    """Get storage client."""
-    global _STORAGE_CLIENT # pylint: disable=global-statement
-    if _STORAGE_CLIENT is None:
-        _STORAGE_CLIENT = storage.Client()
-    return _STORAGE_CLIENT
+  """Get storage client."""
+  global _STORAGE_CLIENT  # pylint: disable=global-statement
+  if _STORAGE_CLIENT is None:
+    _STORAGE_CLIENT = storage.Client()
+  return _STORAGE_CLIENT
+
 
 @blueprint.route('/triage')
 def triage_index():
-    """Triage index."""
-    return render_template('triage.html')
+  """Triage index."""
+  return render_template('triage.html')
+
 
 @blueprint.route('/triage/proxy')
 def triage_proxy():
-    """Proxy to fetch files from GCS buckets securely."""
-    bucket_name = request.args.get('bucket')
-    path = request.args.get('path')
+  """Proxy to fetch files from GCS buckets securely."""
+  bucket_name = request.args.get('bucket')
+  path = request.args.get('path')
 
-    if not bucket_name or not path:
-        return jsonify({'error': 'Missing bucket or path parameters'}), 400
+  if not bucket_name or not path:
+    return jsonify({'error': 'Missing bucket or path parameters'}), 400
 
-    if bucket_name not in ALLOWED_BUCKETS:
-        return jsonify({'error': 'Invalid bucket'}), 403
+  if bucket_name not in ALLOWED_BUCKETS:
+    return jsonify({'error': 'Invalid bucket'}), 403
 
-    try:
-        bucket = get_storage_client().bucket(bucket_name)
-        blob = bucket.blob(path)
+  try:
+    bucket = get_storage_client().bucket(bucket_name)
+    blob = bucket.blob(path)
 
-        if not blob.exists():
-            return jsonify({'error': 'File not found'}), 404
+    if not blob.exists():
+      return jsonify({'error': 'File not found'}), 404
 
-        content = blob.download_as_text()
-        return content, 200, {'Content-Type': 'application/json'}
+    content = blob.download_as_text()
+    return content, 200, {'Content-Type': 'application/json'}
 
-    except Exception as e: # pylint: disable=broad-exception-caught
-        logging.error('Error fetching from GCS: %s', e)
-        return jsonify({'error': 'Internal server error'}), 500
+  except Exception as e:  # pylint: disable=broad-exception-caught
+    logging.error('Error fetching from GCS: %s', e)
+    return jsonify({'error': 'Internal server error'}), 500

--- a/gcp/website/triage_handlers.py
+++ b/gcp/website/triage_handlers.py
@@ -1,0 +1,52 @@
+"""Triage handlers."""
+import logging
+
+from flask import Blueprint, request, jsonify, render_template
+from google.cloud import storage
+
+blueprint = Blueprint('triage_handlers', __name__)
+
+ALLOWED_BUCKETS = {
+    'cve-osv-conversion',
+    'osv-test-cve-osv-conversion'
+}
+
+_STORAGE_CLIENT = None
+
+def get_storage_client():
+    """Get storage client."""
+    global _STORAGE_CLIENT # pylint: disable=global-statement
+    if _STORAGE_CLIENT is None:
+        _STORAGE_CLIENT = storage.Client()
+    return _STORAGE_CLIENT
+
+@blueprint.route('/triage')
+def triage_index():
+    """Triage index."""
+    return render_template('triage.html')
+
+@blueprint.route('/triage/proxy')
+def triage_proxy():
+    """Proxy to fetch files from GCS buckets securely."""
+    bucket_name = request.args.get('bucket')
+    path = request.args.get('path')
+
+    if not bucket_name or not path:
+        return jsonify({'error': 'Missing bucket or path parameters'}), 400
+
+    if bucket_name not in ALLOWED_BUCKETS:
+        return jsonify({'error': 'Invalid bucket'}), 403
+
+    try:
+        bucket = get_storage_client().bucket(bucket_name)
+        blob = bucket.blob(path)
+
+        if not blob.exists():
+            return jsonify({'error': 'File not found'}), 404
+
+        content = blob.download_as_text()
+        return content, 200, {'Content-Type': 'application/json'}
+
+    except Exception as e: # pylint: disable=broad-exception-caught
+        logging.error('Error fetching from GCS: %s', e)
+        return jsonify({'error': 'Internal server error'}), 500


### PR DESCRIPTION
This PR adds a new triage page at `/triage` to help developers compare CVE conversion data. 
It features a 3-column layout where users can select different sources (Test/Prod GCS buckets, API) 
for a given Vulnerability ID. The backend includes a proxy to securely fetch files from 
GCS buckets.


---
*PR created automatically by Jules for task [10975446844985313989](https://jules.google.com/task/10975446844985313989) started by @jess-lowe*