### PR TITLE
feat(vulnfeeds): add Error outcome for 429 status limit in NVD converter

### DIFF
--- a/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
@@ -145,8 +145,9 @@ func processCVE(cve models.NVDCVE, vpRepoCache *cves.VPRepoCache, repoTagsCache 
 func worker(wg *sync.WaitGroup, jobs <-chan models.NVDCVE, _ string, vpRepoCache *cves.VPRepoCache, repoTagsCache *git.RepoTagsCache) {
 	defer wg.Done()
 	for cve := range jobs {
-		if processCVE(cve, vpRepoCache, repoTagsCache) != models.Successful {
-			logger.Info("Failed to generate an OSV record", slog.String("cve", string(cve.ID)))
+		outcome := processCVE(cve, vpRepoCache, repoTagsCache)
+		if outcome != models.Successful {
+			logger.Info("Failed to generate an OSV record", slog.String("cve", string(cve.ID)), slog.String("outcome", outcome.String()))
 		} else {
 			logger.Info("Generated OSV record for "+string(cve.ID), slog.String("cve", string(cve.ID)))
 		}

--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -188,6 +188,10 @@ func GitVersionsToCommits(versionRanges []*osvschema.Range, repos []string, metr
 		}
 		normalizedTags, err := git.NormalizeRepoTags(repo, cache)
 		if err != nil {
+			if strings.Contains(err.Error(), "429") {
+				metrics.Outcome = models.Error
+				return nil, nil, nil
+			}
 			metrics.AddNote("Failed to normalize tags - %s", repo)
 			continue
 		}

--- a/vulnfeeds/conversion/nvd/converter.go
+++ b/vulnfeeds/conversion/nvd/converter.go
@@ -75,6 +75,9 @@ func CVEToOSV(cve models.NVDCVE, repos []string, cache *git.RepoTagsCache, direc
 
 	// If we have ranges, try to resolve them
 	r, un, sR := processRanges(cpeRanges, repos, metrics, cache, models.VersionSourceCPE)
+	if metrics.Outcome == models.Error {
+		return models.Error
+	}
 	resolvedRanges = append(resolvedRanges, r...)
 	unresolvedRanges = append(unresolvedRanges, un...)
 	for _, s := range sR {
@@ -102,6 +105,9 @@ func CVEToOSV(cve models.NVDCVE, repos []string, cache *git.RepoTagsCache, direc
 			metrics.AddNote("Extracted versions from description: %v", textRanges)
 		}
 		r, un, sR := processRanges(textRanges, repos, metrics, cache, models.VersionSourceDescription)
+		if metrics.Outcome == models.Error {
+			return models.Error
+		}
 		resolvedRanges = append(resolvedRanges, r...)
 		unresolvedRanges = append(unresolvedRanges, un...)
 		for _, s := range sR {
@@ -119,7 +125,7 @@ func CVEToOSV(cve models.NVDCVE, repos []string, cache *git.RepoTagsCache, direc
 	affected := MergeRangesAndCreateAffected(resolvedRanges, unresolvedRanges, commits, keys, metrics)
 	v.Affected = append(v.Affected, affected)
 
-	if !outputMetrics && rejectFailed && metrics.Outcome != models.Successful {
+	if metrics.Outcome == models.Error || (!outputMetrics && rejectFailed && metrics.Outcome != models.Successful) {
 		return metrics.Outcome
 	}
 
@@ -155,6 +161,9 @@ func CVEToPackageInfo(cve models.NVDCVE, repos []string, cache *git.RepoTagsCach
 		}
 		logger.Info("Trying to convert version tags to commits", slog.String("cve", string(cve.ID)), slog.Any("versions", versions), slog.Any("repos", repos))
 		cves.VersionInfoToCommits(&versions, repos, cache, metrics)
+		if metrics.Outcome == models.Error {
+			return models.Error
+		}
 	}
 
 	hasAnyFixedCommits := false
@@ -189,6 +198,10 @@ func CVEToPackageInfo(cve models.NVDCVE, repos []string, cache *git.RepoTagsCach
 	versions.AffectedVersions = nil // these have served their purpose and are not required in the resulting output.
 
 	slices.SortStableFunc(versions.AffectedCommits, models.AffectedCommitCompare)
+
+	if metrics.Outcome == models.Error {
+		return metrics.Outcome
+	}
 
 	var pkgInfos []vulns.PackageInfo
 	pi := vulns.PackageInfo{VersionInfo: versions}
@@ -451,6 +464,10 @@ func outputFiles(v *vulns.Vulnerability, dir string, vendor string, product stri
 
 	if err := os.MkdirAll(vulnDir, 0755); err != nil {
 		logger.Info("Failed to create directory "+vulnDir, slog.String("cve", cveID), slog.String("path", vulnDir), slog.Any("err", err))
+	}
+
+	if metrics.Outcome == models.Error {
+		return
 	}
 
 	if !rejectFailed || metrics.Outcome == models.Successful {

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -1095,6 +1095,10 @@ func VersionInfoToCommits(v *models.VersionInfo, repos []string, cache *git.Repo
 	for _, repo := range repos {
 		normalizedTags, err := git.NormalizeRepoTags(repo, cache)
 		if err != nil {
+			if strings.Contains(err.Error(), "429") {
+				metrics.Outcome = models.Error
+				return
+			}
 			metrics.AddNote("Failed to normalize tags %s %s", repo, err)
 			continue
 		}

--- a/vulnfeeds/models/metrics.go
+++ b/vulnfeeds/models/metrics.go
@@ -24,6 +24,7 @@ const (
 	NoCommitRanges                             // No viable commit ranges could be calculated from the repository for the CVE's CPE(s).
 	NoRanges                                   // No version ranges could be extracted from the record.
 	FixUnresolvable                            // Partial resolution of versions, resulting in a false positive.
+	Error                                      // A generic error occurred (e.g. 429 Status Error).
 )
 
 // RefTagDenyList contains reference tags that are often associated with unreliable or
@@ -36,7 +37,7 @@ var RefTagDenyList = []string{
 }
 
 func (c ConversionOutcome) String() string {
-	return [...]string{"ConversionUnknown", "Successful", "Rejected", "NoSoftware", "NoRepos", "NoCommitRanges", "NoRanges", "FixUnresolvable"}[c]
+	return [...]string{"ConversionUnknown", "Successful", "Rejected", "NoSoftware", "NoRepos", "NoCommitRanges", "NoRanges", "FixUnresolvable", "Error"}[c]
 }
 
 // ConversionMetrics holds the collected data about the conversion process for a single CVE.


### PR DESCRIPTION
Added a new ConversionOutcome `Error` to represent general conversion errors and explicitly applied it when encountering `429` (RateLimit) errors while normalizing tags for git repositories in the NVD OSV conversion pipeline.

This logic ensures that if the vulnerability conversion attempts to interact with external APIs (like GitHub) and fails due to rate-limiting, the vulnerability records are rejected and not generated, thus preventing malformed/incomplete generation of the OSV records.

---
*PR created automatically by Jules for task [1941614552333386379](https://jules.google.com/task/1941614552333386379) started by @jess-lowe*