### PR TITLE
fix: retain Package metadata in combine-to-osv when merging Affected elements

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -276,9 +277,9 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 				repo := strings.ToLower(r.GetRepo())
 				if _, ok := nvdRepoMap[repo]; !ok {
 					// create a copy to avoid mutating the original
-					affectedCopy := *affected
+					affectedCopy := proto.Clone(affected).(*osvschema.Affected)
 					affectedCopy.Ranges = []*osvschema.Range{r}
-					nvdRepoMap[repo] = &affectedCopy
+					nvdRepoMap[repo] = affectedCopy
 				} else {
 					nvdRepoMap[repo].Ranges = append(nvdRepoMap[repo].Ranges, r)
 				}
@@ -292,9 +293,9 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 			if r.GetRepo() != "" {
 				repo := strings.ToLower(r.GetRepo())
 				if _, ok := cve5RepoMap[repo]; !ok {
-					affectedCopy := *affected
+					affectedCopy := proto.Clone(affected).(*osvschema.Affected)
 					affectedCopy.Ranges = []*osvschema.Range{r}
-					cve5RepoMap[repo] = &affectedCopy
+					cve5RepoMap[repo] = affectedCopy
 				} else {
 					cve5RepoMap[repo].Ranges = append(cve5RepoMap[repo].Ranges, r)
 				}
@@ -344,9 +345,9 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 
 			// We must construct the combined affected entry taking properties like Package, DatabaseSpecific, etc.
 			// Try to preserve as much package info as possible, prioritizing CVE5.
-			newAffected := *cveAffected
+			newAffected := proto.Clone(cveAffected).(*osvschema.Affected)
 			newAffected.Ranges = newAffectedRanges
-			newRepoAffectedMap[repo] = &newAffected
+			newRepoAffectedMap[repo] = newAffected
 		} else {
 			newRepoAffectedMap[repo] = cveAffected
 		}

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -269,22 +269,35 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 		return nvdAffected
 	}
 
-	nvdRepoMap := make(map[string][]*osvschema.Range)
+	nvdRepoMap := make(map[string]*osvschema.Affected)
 	for _, affected := range nvdAffected {
 		for _, r := range affected.GetRanges() {
 			if r.GetRepo() != "" {
 				repo := strings.ToLower(r.GetRepo())
-				nvdRepoMap[repo] = append(nvdRepoMap[repo], r)
+				if _, ok := nvdRepoMap[repo]; !ok {
+					// create a copy to avoid mutating the original
+					affectedCopy := *affected
+					affectedCopy.Ranges = []*osvschema.Range{r}
+					nvdRepoMap[repo] = &affectedCopy
+				} else {
+					nvdRepoMap[repo].Ranges = append(nvdRepoMap[repo].Ranges, r)
+				}
 			}
 		}
 	}
 
-	cve5RepoMap := make(map[string][]*osvschema.Range)
+	cve5RepoMap := make(map[string]*osvschema.Affected)
 	for _, affected := range cve5Affected {
 		for _, r := range affected.GetRanges() {
 			if r.GetRepo() != "" {
 				repo := strings.ToLower(r.GetRepo())
-				cve5RepoMap[repo] = append(cve5RepoMap[repo], r)
+				if _, ok := cve5RepoMap[repo]; !ok {
+					affectedCopy := *affected
+					affectedCopy.Ranges = []*osvschema.Range{r}
+					cve5RepoMap[repo] = &affectedCopy
+				} else {
+					cve5RepoMap[repo].Ranges = append(cve5RepoMap[repo].Ranges, r)
+				}
 			}
 		}
 	}
@@ -292,8 +305,10 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 	newRepoAffectedMap := make(map[string]*osvschema.Affected)
 
 	// Finds ranges with the same repo and merges them into one affected set.
-	for repo, cveRanges := range cve5RepoMap {
-		if nvdRanges, ok := nvdRepoMap[repo]; ok {
+	for repo, cveAffected := range cve5RepoMap {
+		cveRanges := cveAffected.GetRanges()
+		if nvdAffected, ok := nvdRepoMap[repo]; ok {
+			nvdRanges := nvdAffected.GetRanges()
 			var newAffectedRanges []*osvschema.Range
 
 			// Found a match. If NVD has more ranges, use its ranges.
@@ -326,21 +341,20 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 
 			// Remove from map so we know which NVD packages are left.
 			delete(nvdRepoMap, repo)
-			newRepoAffectedMap[repo] = &osvschema.Affected{
-				Ranges: newAffectedRanges,
-			}
+
+			// We must construct the combined affected entry taking properties like Package, DatabaseSpecific, etc.
+			// Try to preserve as much package info as possible, prioritizing CVE5.
+			newAffected := *cveAffected
+			newAffected.Ranges = newAffectedRanges
+			newRepoAffectedMap[repo] = &newAffected
 		} else {
-			newRepoAffectedMap[repo] = &osvschema.Affected{
-				Ranges: cveRanges,
-			}
+			newRepoAffectedMap[repo] = cveAffected
 		}
 	}
 
 	// Add remaining NVD packages that were not in cve5.
-	for repo, nvdRange := range nvdRepoMap {
-		newRepoAffectedMap[repo] = &osvschema.Affected{
-			Ranges: nvdRange,
-		}
+	for repo, nvdAffected := range nvdRepoMap {
+		newRepoAffectedMap[repo] = nvdAffected
 	}
 
 	var combinedAffected []*osvschema.Affected //nolint:prealloc

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -137,6 +137,10 @@ func TestPickAffectedInformation(t *testing.T) {
 	// Base data for tests
 	cve5Base := []*osvschema.Affected{
 		{
+			Package: &osvschema.Package{
+				Ecosystem: "Go",
+				Name:      "github.com/example/repoA",
+			},
 			Ranges: []*osvschema.Range{
 				{
 					Type: osvschema.Range_GIT,
@@ -152,6 +156,10 @@ func TestPickAffectedInformation(t *testing.T) {
 
 	nvdBase := []*osvschema.Affected{
 		{
+			Package: &osvschema.Package{
+				Ecosystem: "Go",
+				Name:      "github.com/example/repoA",
+			},
 			Ranges: []*osvschema.Range{
 				{
 					Type: osvschema.Range_GIT,
@@ -188,6 +196,10 @@ func TestPickAffectedInformation(t *testing.T) {
 			// cve5's "1.0.1" fixed version should be kept
 			wantAffected: []*osvschema.Affected{
 				{
+					Package: &osvschema.Package{
+						Ecosystem: "Go",
+						Name:      "github.com/example/repoA",
+					},
 					Ranges: []*osvschema.Range{
 						{
 							Type:   osvschema.Range_GIT,
@@ -214,6 +226,10 @@ func TestPickAffectedInformation(t *testing.T) {
 			name: "NVD provides missing introduced version",
 			cve5Affected: []*osvschema.Affected{
 				{
+					Package: &osvschema.Package{
+						Ecosystem: "Go",
+						Name:      "github.com/example/repoA",
+					},
 					Ranges: []*osvschema.Range{
 						{
 							Type: osvschema.Range_GIT,
@@ -241,6 +257,10 @@ func TestPickAffectedInformation(t *testing.T) {
 			},
 			wantAffected: []*osvschema.Affected{
 				{
+					Package: &osvschema.Package{
+						Ecosystem: "Go",
+						Name:      "github.com/example/repoA",
+					},
 					Ranges: []*osvschema.Range{
 						{
 							Type: osvschema.Range_GIT,
@@ -258,6 +278,10 @@ func TestPickAffectedInformation(t *testing.T) {
 			name: "NVD provides missing fixed version",
 			cve5Affected: []*osvschema.Affected{
 				{
+					Package: &osvschema.Package{
+						Ecosystem: "Go",
+						Name:      "github.com/example/repoA",
+					},
 					Ranges: []*osvschema.Range{
 						{
 							Type: osvschema.Range_GIT,
@@ -285,6 +309,10 @@ func TestPickAffectedInformation(t *testing.T) {
 			},
 			wantAffected: []*osvschema.Affected{
 				{
+					Package: &osvschema.Package{
+						Ecosystem: "Go",
+						Name:      "github.com/example/repoA",
+					},
 					Ranges: []*osvschema.Range{
 						{
 							Type: osvschema.Range_GIT,


### PR DESCRIPTION
fix: retain Package metadata in combine-to-osv when merging Affected elements

When picking affected information in `combine-to-osv`, the merge logic was creating new `osvschema.Affected` structs and transferring only the `osvschema.Range` slices, discarding any properties present on the original object such as `Package`, `Versions`, `DatabaseSpecific`, etc.

This change preserves the entire base `osvschema.Affected` struct when replacing or appending ranges, resolving issues where resulting records were missing ecosystem and package details. Main tests have been updated to verify `Package` components survive the merge logic.

---
*PR created automatically by Jules for task [163538135686354671](https://jules.google.com/task/163538135686354671) started by @jess-lowe*