### PR TITLE
fix: Prevent 500 error on missing type field

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -31,6 +31,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      - uses: amannn/action-semantic-pull-request@v6.1.1 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -31,6 +31,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6.1.1 # v6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -958,8 +958,8 @@ def list_packages(vuln_affected: list[dict]):
 
   for affected in vuln_affected:
     if 'package' in affected:
-      package_entry = affected['package'].get('ecosystem', '') + '/' + affected[
-          'package'].get('name', '')
+      package_entry = affected['package'].get(
+          'ecosystem', '') + '/' + affected['package'].get('name', '')
       if package_entry not in packages:
         packages.append(package_entry)
     for affected_range in affected.get('ranges', []):

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -464,7 +464,7 @@ def add_links(record: dict):
   for entry in record.get('affected', []):
     for i, affected_range in enumerate(entry.get('ranges', [])):
       affected_range['id'] = i
-      if affected_range['type'] != 'GIT':
+      if affected_range.get('type') != 'GIT':
         continue
 
       repo_url = affected_range.get('repo')
@@ -944,9 +944,9 @@ def git_repo(affected):
 
 @blueprint.app_template_filter('package_in_ecosystem')
 def package_in_ecosystem(package):
-  ecosystem = osv.ecosystems.normalize(package['ecosystem'])
+  ecosystem = osv.ecosystems.normalize(package.get('ecosystem', ''))
   if ecosystem in osv.ecosystems.package_urls:
-    return osv.ecosystems.package_urls[ecosystem] + package['name']
+    return osv.ecosystems.package_urls[ecosystem] + package.get('name', '')
   return ''
 
 
@@ -958,13 +958,13 @@ def list_packages(vuln_affected: list[dict]):
 
   for affected in vuln_affected:
     if 'package' in affected:
-      package_entry = affected['package']['ecosystem'] + '/' + affected[
-          'package']['name']
+      package_entry = affected['package'].get('ecosystem', '') + '/' + affected[
+          'package'].get('name', '')
       if package_entry not in packages:
         packages.append(package_entry)
     for affected_range in affected.get('ranges', []):
-      if affected_range['type'] == 'GIT':
-        parsed_scheme = strip_scheme(affected_range['repo'])
+      if affected_range.get('type') == 'GIT':
+        parsed_scheme = strip_scheme(affected_range.get('repo', ''))
         if parsed_scheme not in packages:
           packages.append(parsed_scheme)
 


### PR DESCRIPTION
Use `.get()` for dictionary lookups in frontend_handlers.py to safely handle missing data fields and prevent 500 Internal Server Errors caused by KeyErrors when accessing vulnerability records that are missing these fields.

---
*PR created automatically by Jules for task [7939870419218737424](https://jules.google.com/task/7939870419218737424) started by @jess-lowe*