### PR TITLE
fix: prevent 0001-01-01 published dates in Debian converter

### DIFF
--- a/vulnfeeds/cmd/converters/debian/main.go
+++ b/vulnfeeds/cmd/converters/debian/main.go
@@ -111,10 +111,9 @@ func generateOSVFromDebianTracker(debianData DebianSecurityTrackerData, debianRe
 			if !ok {
 				v = &vulns.Vulnerability{
 					Vulnerability: &osvschema.Vulnerability{
-						Id:        "DEBIAN-" + cveID,
-						Upstream:  []string{cveID},
-						Published: timestamppb.New(currentNVDCVE.CVE.Published.Time),
-						Details:   cveData.Description,
+						Id:       "DEBIAN-" + cveID,
+						Upstream: []string{cveID},
+						Details:  cveData.Description,
 						References: []*osvschema.Reference{
 							{
 								Type: osvschema.Reference_ADVISORY,
@@ -123,6 +122,11 @@ func generateOSVFromDebianTracker(debianData DebianSecurityTrackerData, debianRe
 						},
 					},
 				}
+
+				if !currentNVDCVE.CVE.Published.Time.IsZero() {
+					v.Published = timestamppb.New(currentNVDCVE.CVE.Published.Time)
+				}
+
 				if currentNVDCVE.CVE.Metrics != nil {
 					v.AddSeverity(currentNVDCVE.CVE.Metrics)
 				}

--- a/vulnfeeds/cmd/converters/debian/main.go
+++ b/vulnfeeds/cmd/converters/debian/main.go
@@ -123,7 +123,7 @@ func generateOSVFromDebianTracker(debianData DebianSecurityTrackerData, debianRe
 					},
 				}
 
-				if !currentNVDCVE.CVE.Published.Time.IsZero() {
+				if !currentNVDCVE.CVE.Published.IsZero() {
 					v.Published = timestamppb.New(currentNVDCVE.CVE.Published.Time)
 				}
 


### PR DESCRIPTION
Fixes an issue where Debian-CVE records were generated with a published date of year 1 (0001-01-01T00:00:00Z) when the NVD CVE did not exist or had no published date. It omits the `Published` field in these cases, letting the worker set the published date when first detected.

---
*PR created automatically by Jules for task [785349618750554831](https://jules.google.com/task/785349618750554831) started by @jess-lowe*