### PR TITLE
feat: add copy text button to CVE Conversion Triager JSON boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ hurl-scripts/
 temp/*
 **/tmp/**
 gcp/api/v1/osv/**
-.hypothesis
+.hypothesis/gcp/website/.venv/

--- a/gcp/website/frontend3/src/templates/triage.html
+++ b/gcp/website/frontend3/src/templates/triage.html
@@ -45,10 +45,15 @@
         </div>
       </div>
       <div class="content-display">
+        <clipboard-copy class="code-card-copy hidden" id="copy-btn-{{ i }}" for="json-content-{{ i }}">
+          <md-icon-button class="icon">
+            <md-icon>content_copy</md-icon>
+          </md-icon-button>
+        </clipboard-copy>
         <div class="loading-spinner hidden">
           <md-circular-progress indeterminate></md-circular-progress>
         </div>
-        <pre class="json-content">Select a source to view content</pre>
+        <pre class="json-content" id="json-content-{{ i }}">Select a source to view content</pre>
       </div>
     </div>
     {% endfor %}

--- a/gcp/website/frontend3/src/triage.js
+++ b/gcp/website/frontend3/src/triage.js
@@ -116,28 +116,34 @@ document.addEventListener("DOMContentLoaded", () => {
     const select = column.querySelector(".source-select");
     const contentPre = column.querySelector(".json-content");
     const spinner = column.querySelector(".loading-spinner");
+    const copyBtn = column.querySelector(".code-card-copy");
     const sourceKey = select.value;
     const vulnId = vulnIdInput.value.trim();
 
     if (!sourceKey) {
         contentPre.textContent = "Select a source to view content";
+        copyBtn.classList.add("hidden");
         return;
     }
 
     if (!vulnId) {
       contentPre.textContent = "Please enter a Vulnerability ID";
+      copyBtn.classList.add("hidden");
       return;
     }
 
     spinner.classList.remove("hidden");
+    copyBtn.classList.add("hidden");
     contentPre.textContent = "";
 
     fetchData(sourceKey, vulnId)
       .then((data) => {
         contentPre.innerHTML = syntaxHighlight(data);
+        copyBtn.classList.remove("hidden");
       })
       .catch((error) => {
         contentPre.textContent = error.message;
+        copyBtn.classList.add("hidden");
       })
       .finally(() => {
         spinner.classList.add("hidden");

--- a/gcp/website/frontend3/src/triage.js
+++ b/gcp/website/frontend3/src/triage.js
@@ -170,4 +170,17 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     });
   });
+
+  // Handle clipboard copy feedback
+  document.addEventListener('clipboard-copy', (event) => {
+    const copyButton = event.target;
+    const icon = copyButton.querySelector('md-icon');
+    if (icon) {
+      const originalText = icon.textContent;
+      icon.textContent = 'check';
+      setTimeout(() => {
+        icon.textContent = originalText;
+      }, 2000);
+    }
+  });
 });

--- a/gcp/website/frontend3/src/triage.scss
+++ b/gcp/website/frontend3/src/triage.scss
@@ -81,6 +81,23 @@
   overflow: auto;
   position: relative;
   background-color: #1e1e1e;
+
+  .code-card-copy {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 10;
+
+    .icon {
+      background: #3c4043;
+      border-radius: 999px;
+      --md-sys-color-on-surface-variant: #fff;
+    }
+
+    &:hover .icon {
+      background: #555;
+    }
+  }
 }
 
 .json-content {

--- a/gcp/website/frontend3/src/triage.scss
+++ b/gcp/website/frontend3/src/triage.scss
@@ -84,18 +84,21 @@
 
   .code-card-copy {
     position: absolute;
-    top: 8px;
+    bottom: 8px;
     right: 8px;
     z-index: 10;
 
     .icon {
-      background: #3c4043;
+      background: #c5221f;
       border-radius: 999px;
       --md-sys-color-on-surface-variant: #fff;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     &:hover .icon {
-      background: #555;
+      background: #ad0300;
     }
   }
 }


### PR DESCRIPTION
Adds a copy text button to the JSON boxes in the CVE Conversion Triager. Uses the existing `<clipboard-copy>` component pattern from the home page.

---
*PR created automatically by Jules for task [11751798741211651104](https://jules.google.com/task/11751798741211651104) started by @jess-lowe*