### PR TITLE
perf: optimize memory usage during Debian CVE conversion

### DIFF
--- a/vulnfeeds/cmd/converters/alpine/main.go
+++ b/vulnfeeds/cmd/converters/alpine/main.go
@@ -50,8 +50,16 @@ func main() {
 		logger.Fatal("Can't create output path", slog.Any("err", err))
 	}
 
-	allCVEs := vulns.LoadAllCVEs(defaultCvePath)
 	allAlpineSecDB := getAlpineSecDBData()
+
+	targetCVEs := make(map[string]bool)
+	for cveID := range allAlpineSecDB {
+		if strings.HasPrefix(cveID, "CVE") {
+			targetCVEs[cveID] = true
+		}
+	}
+
+	allCVEs := vulns.LoadTargetCVEs(defaultCvePath, targetCVEs)
 	osvVulnerabilities := generateAlpineOSV(allAlpineSecDB, allCVEs)
 
 	vulnerabilities := make([]*osvschema.Vulnerability, 0, len(osvVulnerabilities))

--- a/vulnfeeds/cmd/converters/debian/main.go
+++ b/vulnfeeds/cmd/converters/debian/main.go
@@ -57,7 +57,16 @@ func main() {
 		logger.Fatal("Failed to get Debian distro info data", slog.Any("err", err))
 	}
 
-	allCVEs := vulns.LoadAllCVEs(defaultCvePath)
+	targetCVEs := make(map[string]bool)
+	for _, pkg := range debianData {
+		for cveID := range pkg {
+			if strings.HasPrefix(cveID, "CVE") {
+				targetCVEs[cveID] = true
+			}
+		}
+	}
+
+	allCVEs := vulns.LoadTargetCVEs(defaultCvePath, targetCVEs)
 	osvCVEs := generateOSVFromDebianTracker(debianData, debianReleaseMap, allCVEs)
 
 	vulnerabilities := make([]*osvschema.Vulnerability, 0, len(osvCVEs))

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -818,6 +818,12 @@ func CheckQuality(text string) QualityCheck {
 
 // LoadAllCVEs loads the downloaded CVE's from the NVD database into memory.
 func LoadAllCVEs(cvePath string) map[models.CVEID]models.Vulnerability {
+	return LoadTargetCVEs(cvePath, nil)
+}
+
+// LoadTargetCVEs loads the downloaded CVE's from the NVD database into memory,
+// filtering by a set of target CVE IDs if provided.
+func LoadTargetCVEs(cvePath string, targetCVEs map[string]bool) map[models.CVEID]models.Vulnerability {
 	dir, err := os.ReadDir(cvePath)
 	if err != nil {
 		logger.Fatal("Failed to read dir", slog.String("path", cvePath), slog.Any("err", err))
@@ -849,7 +855,9 @@ func LoadAllCVEs(cvePath string) map[models.CVEID]models.Vulnerability {
 			}
 
 			for _, item := range nvdcve.Vulnerabilities {
-				vulnsChan <- item
+				if targetCVEs == nil || targetCVEs[string(item.CVE.ID)] {
+					vulnsChan <- item
+				}
 			}
 			logger.Info("Loaded "+filename, slog.String("cve", filename))
 		}(entry.Name())


### PR DESCRIPTION
The `generateOSVFromDebianTracker` function requires access to corresponding NVD CVE data to populate metadata like `Published` time and CVSS metrics. Previously, `vulns.LoadAllCVEs` was called to blindly load every single NVD CVE into a giant `map[models.CVEID]models.Vulnerability`. Since the NVD dataset is massive, allocating structs for unreferenced CVEs causes unnecessary memory bloat and performance degradation.

By explicitly parsing the `DebianSecurityTrackerData` first to find out which CVEs are actually needed, we can construct a target map and pass it down. A new function `LoadTargetCVEs` was added to `vulns/vulns.go` which conditionally checks the target map before pushing to the channel. This prevents loading unneeded vulnerabilities into memory and drastically speeds up processing.

---
*PR created automatically by Jules for task [1462681954862797174](https://jules.google.com/task/1462681954862797174) started by @jess-lowe*